### PR TITLE
Align NavBar theme toggle with Tailwind themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A modern and responsive portfolio website built using Vite, React, Tailwind CSS,
 ## Table of Contents
 
 - [Features](#features)
+- [Theme Modes](#theme-modes)
 - [Technologies](#technologies)
 - [Getting Started](#getting-started)
 - [Project Structure](#project-structure)
@@ -23,6 +24,15 @@ A modern and responsive portfolio website built using Vite, React, Tailwind CSS,
 - **SEO Optimized**: Meta tags and structure optimized for search engines.
 - **Custom Components**: Reusable and customizable React components.
 - **Fast Loading**: Built with Vite for lightning-fast development and production builds.
+
+### Theme Modes
+
+The Tailwind-driven design tokens support two named themes that are referenced throughout the UI:
+
+- `dark` – the high-contrast midnight palette showcased in the redesigned layout.
+- `light` – a softer variant tuned for daylight viewing while preserving the same design tokens.
+
+The current selection is stored in `localStorage` (via `react-hook-theme`) so the choice persists across reloads and sessions.
 
 ## Technologies
 

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react"
+import { useTheme } from "react-hook-theme"
 
 const navigation = [
   { name: "Home", href: "#hero" },
@@ -7,10 +8,32 @@ const navigation = [
   { name: "Contact", href: "#contact" },
 ]
 
+const THEMES = {
+  dark: "dark",
+  light: "light",
+}
+
 const NavBar = () => {
   const [active, setActive] = useState("Home")
   const [menuOpen, setMenuOpen] = useState(false)
   const navRef = useRef(null)
+  const { theme, setTheme } = useTheme()
+
+  const isDark = theme === THEMES.dark
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (isDark) {
+      root.classList.add("dark")
+    } else {
+      root.classList.remove("dark")
+    }
+  }, [isDark])
+
+  const handleThemeChange = (event) => {
+    const nextIsDark = event.target.checked
+    setTheme(nextIsDark ? THEMES.dark : THEMES.light)
+  }
 
   useEffect(() => {
     const handleResize = () => {
@@ -70,28 +93,76 @@ const NavBar = () => {
             </a>
           ))}
         </div>
-        <button
-          type="button"
-          className="nav-toggle lg:hidden"
-          onClick={() => setMenuOpen((open) => !open)}
-          aria-label="Toggle navigation"
-          aria-expanded={menuOpen}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            className="h-5 w-5"
+        <div className="flex items-center gap-2">
+          <label className={`theme-toggle ${isDark ? 'is-dark' : ''}`}>
+            <input
+              type="checkbox"
+              className="theme-toggle-input"
+              onChange={handleThemeChange}
+              checked={isDark}
+              aria-label={isDark ? "Activate light theme" : "Activate dark theme"}
+            />
+            <span aria-hidden="true" className="theme-toggle-visual">
+              {isDark ? (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  className="theme-toggle-icon"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 3.75a8.25 8.25 0 1 0 8.25 8.25c0-.28-.015-.557-.044-.832A6 6 0 0 1 12 3.75Z"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  className="theme-toggle-icon"
+                >
+                  <circle cx="12" cy="12" r="4" />
+                  <path strokeLinecap="round" d="M12 3v2" />
+                  <path strokeLinecap="round" d="M12 19v2" />
+                  <path strokeLinecap="round" d="m5.64 5.64 1.42 1.42" />
+                  <path strokeLinecap="round" d="m16.94 16.94 1.42 1.42" />
+                  <path strokeLinecap="round" d="M3 12h2" />
+                  <path strokeLinecap="round" d="M19 12h2" />
+                  <path strokeLinecap="round" d="m5.64 18.36 1.42-1.42" />
+                  <path strokeLinecap="round" d="m16.94 7.06 1.42-1.42" />
+                </svg>
+              )}
+            </span>
+          </label>
+          <button
+            type="button"
+            className="nav-toggle lg:hidden"
+            onClick={() => setMenuOpen((open) => !open)}
+            aria-label="Toggle navigation"
+            aria-expanded={menuOpen}
           >
-            {menuOpen ? (
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            ) : (
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-            )}
-          </svg>
-        </button>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              className="h-5 w-5"
+            >
+              {menuOpen ? (
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+              )}
+            </svg>
+          </button>
+        </div>
       </nav>
       {menuOpen && (
         <div className="mobile-menu lg:hidden">

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,30 @@
     @apply inline-flex h-11 w-11 items-center justify-center rounded-full border border-surface-border bg-transparent text-ink transition hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60;
   }
 
+  .theme-toggle {
+    @apply inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-full border border-surface-border bg-surface/60 text-ink transition hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60;
+  }
+
+  .theme-toggle.is-dark {
+    @apply border-accent/40 bg-accent/15 text-ink shadow-glow;
+  }
+
+  .theme-toggle-input {
+    @apply sr-only;
+  }
+
+  .theme-toggle-visual {
+    @apply pointer-events-none flex h-full w-full items-center justify-center;
+  }
+
+  .theme-toggle-input:focus-visible + .theme-toggle-visual {
+    @apply rounded-full ring-2 ring-accent/60 outline-none;
+  }
+
+  .theme-toggle-icon {
+    @apply h-5 w-5;
+  }
+
   .nav-link {
     @apply relative inline-flex items-center rounded-full px-5 py-2 text-sm font-medium text-ink/80 transition hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60;
   }


### PR DESCRIPTION
## Summary
- sync the NavBar theme toggle with the Tailwind dark/light palette and ensure the checkbox state reflects the active theme
- add component styles for the custom toggle control while keeping dark-mode class management aligned with the new design system
- document the supported `dark` and `light` theme names along with persistence behavior in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2d1d9809c832d8e35d23c8c7ca81d